### PR TITLE
Bump supported Elixir to v1.16 through v1.20

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,6 @@ jobs:
       # we additionally test the maximum supported OTP version.
       matrix:
         include:
-          - elixir: '1.15' # supports OTP 24 - 26
-            otp: '24'
           - elixir: '1.16' # supports OTP 24 - 26
             otp: '24'
           - elixir: '1.17' # supports OTP 25 - 27
@@ -42,8 +40,10 @@ jobs:
             otp: '25'
           - elixir: '1.19' # supports OTP 26 - 28
             otp: '26'
-          - elixir: '1.19'
-            otp: '28'
+          - elixir: '1.20' # supports OTP 27 - 29
+            otp: '27'
+          - elixir: '1.20'
+            otp: '29'
 
     permissions:
       contents: read

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.19.4-otp-28
-erlang 28
+elixir 1.20
+erlang 29

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule BitwiseIp.MixProject do
     [
       app: :bitwise_ip,
       version: "1.2.0",
-      elixir: "~> 1.15",
+      elixir: "~> 1.16",
       description: "Efficient IP address operations using bitwise arithmetic",
       package: %{
         files: ~w[lib mix.exs README.md LICENSE],


### PR DESCRIPTION
There appear to be no new compilation warnings for bitwise_ip itself on Elixir v1.20, so this is merely housekeeping to align the package & CI with the latest [compatibility matrix](https://elixir.hexdocs.pm/compatibility-and-deprecations.html).